### PR TITLE
Update Liberty Maven plugin version

### DIFF
--- a/OL-Blockchain/pom.xml
+++ b/OL-Blockchain/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <!-- Plugin versions -->
-        <version.liberty-maven-plugin>3.1</version.liberty-maven-plugin>
+        <version.liberty-maven-plugin>3.2.1</version.liberty-maven-plugin>
         <version.maven-failsafe-plugin>2.22.2</version.maven-failsafe-plugin>
         <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
         <version.maven-war-plugin>3.2.3</version.maven-war-plugin>


### PR DESCRIPTION
With the current version 3.1 of Liberty Maven plugin, the Start Server command times out if it takes longer than 30 seconds (which is the case on my machine).

Update to use Liberty Maven plugin 3.2.1 which has a longer default timeout value of 90 seconds.